### PR TITLE
stddev.add(v) always return None

### DIFF
--- a/bfxhfindicators/stddev.py
+++ b/bfxhfindicators/stddev.py
@@ -46,7 +46,7 @@ class StdDeviation(Indicator):
 
     if len(self._buffer) > self._p:
       del self._buffer[0]
-    elif len(self._buffer) <= self._p:
+    elif len(self._buffer) < self._p:
       return
 
     super().add(StdDeviation.bufferStdDev(self._buffer, self._p))


### PR DESCRIPTION
Stddev.add(v) seems to never return value other than None when buffer size equals seed period.

This issue was discovered with #3 
