### PR TITLE
feat: support fixed size deque for base Indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,16 @@ pip3 install -r requirements.txt
 python3 setup.py install
 ```
 
+```sh
+pip3 install git+https://github.com/bitfinexcom/bfx-hf-indicators-py.git@master
+```
+
 ## Quickstart
 
 ```python
 from bfxhfindicators import RSI
 
-rsi = RSI([14])
+rsi = RSI(14)
 
 rsi.add(14000)
 rsi.add(14010)

--- a/bfxhfindicators/acceleration.py
+++ b/bfxhfindicators/acceleration.py
@@ -3,18 +3,17 @@ from bfxhfindicators.roc import ROC
 from math import isfinite
 
 class Acceleration(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
-    self._roc = ROC([period])
+    self._roc = ROC(period, cache_size)
     self._buffer = []
  
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'acc',
       'name': 'Acceleration(%f)' % (period),
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/accumulation_distribution.py
+++ b/bfxhfindicators/accumulation_distribution.py
@@ -14,14 +14,15 @@ class AccumulationDistribution(Indicator):
 
     return moneyFlowMult * vol
   
-  def __init__(self, args = []):
+  def __init__(self, cache_size=None):
     super().__init__({
-      'args': args,
+      'args': [cache_size],
       'id': 'ad',
       'name': 'Accum/Dist',
       'seed_period': 0,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def update(self, candle):

--- a/bfxhfindicators/accumulative_swing_index.py
+++ b/bfxhfindicators/accumulative_swing_index.py
@@ -2,19 +2,18 @@ from bfxhfindicators.indicator import Indicator
 from math import isfinite, exp, pow
 
 class AccumulativeSwingIndex(Indicator):
-  def __init__(self, args = []):
-    [ limitMoveValue ] = args
-
+  def __init__(self, limitMoveValue, cache_size=None):
     self._lmv = limitMoveValue
     self._prevCandle = None
  
     super().__init__({
-      'args': args,
+      'args': [limitMoveValue, cache_size],
       'id': 'asi',
       'name': 'ASI(%f)' % limitMoveValue,
       'seed_period': None,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def calcSI(candle, prevCandle, lmv):

--- a/bfxhfindicators/alma.py
+++ b/bfxhfindicators/alma.py
@@ -2,19 +2,18 @@ from bfxhfindicators.indicator import Indicator
 from math import isfinite, exp, pow
 
 class ALMA(Indicator):
-  def __init__(self, args = []):
-    [ period, offset, sigma ] = args
-
+  def __init__(self, period, offset, sigma, cache_size=None):
     self._p = period
     self._offset = offset
     self._s = sigma
     self._buffer = []
  
     super().__init__({
-      'args': args,
+      'args': [period, offset, sigma, cache_size],
       'id': 'alma',
       'name': 'ALMA(%f, %f, %f)' % (period, offset, sigma),
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/atr.py
+++ b/bfxhfindicators/atr.py
@@ -1,20 +1,19 @@
 from bfxhfindicators.indicator import Indicator
 
 class ATR(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
     self._prevCandle = None
     self._buffer = []
  
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'atr',
       'name': 'ATR(%f)' % period,
       'seed_period': period,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/awesome_oscillator.py
+++ b/bfxhfindicators/awesome_oscillator.py
@@ -2,17 +2,18 @@ from bfxhfindicators.indicator import Indicator
 from bfxhfindicators.sma import SMA
 
 class AO(Indicator):
-  def __init__(self, args = []):
-    self._smaShort = SMA([5])
-    self._smaLong = SMA([34])
+  def __init__(self, period, cache_size=None):
+    self._smaShort = SMA(period, cache_size)
+    self._smaLong = SMA(period, cache_size)
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'ao',
       'name': 'AO',
       'seed_period': None,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/balance_of_power.py
+++ b/bfxhfindicators/balance_of_power.py
@@ -1,7 +1,10 @@
 from bfxhfindicators.indicator import Indicator
 
 class BOP(Indicator):
-  def __init__(self, args = []):
+  def __init__(self, args=None):
+    if not args:
+        args = []
+
     super().__init__({
       'args': args,
       'id': 'bop',

--- a/bfxhfindicators/bbands.py
+++ b/bfxhfindicators/bbands.py
@@ -3,16 +3,14 @@ from bfxhfindicators.sma import SMA
 from bfxhfindicators.stddev import StdDeviation
 
 class BollingerBands(Indicator):
-  def __init__(self, args = []):
-    [ period, mul ] = args
-
+  def __init__(self, period, mul, cache_size=None):
     self._p = period
     self._m = mul
-    self._sma = SMA([period])
+    self._sma = SMA(period, cache_size)
     self._stddev = StdDeviation([period])
 
     super().__init__({
-      'args': args,
+      'args': [period, mul, cache_size],
       'id': 'bbands',
       'name': 'BBANDS(%f, %f)' % (period, mul),
       'seed_period': period

--- a/bfxhfindicators/chaikin_money_flow.py
+++ b/bfxhfindicators/chaikin_money_flow.py
@@ -1,20 +1,19 @@
 from bfxhfindicators.indicator import Indicator
 
 class CMF(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
     self._bufferVol = []
     self._bufferMFV = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'cmf',
       'name': 'CMF(%f)' % period,
       'seed_period': period,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/chaikin_oscillator.py
+++ b/bfxhfindicators/chaikin_oscillator.py
@@ -4,20 +4,19 @@ from bfxhfindicators.accumulation_distribution import AccumulationDistribution
 from math import isfinite
 
 class ChaikinOsc(Indicator):
-  def __init__(self, args = []):
-    [ short, long ] = args
-
-    self._shortEMA = EMA([short])
-    self._longEMA = EMA([long])
+  def __init__(self, short, long, cache_size=None):
+    self._shortEMA = EMA(short, cache_size)
+    self._longEMA = EMA(long, cache_size)
     self._adl = AccumulationDistribution()
 
     super().__init__({
-      'args': args,
+      'args': [short, long, cache_size],
       'id': 'chaikinosc',
       'name': 'ChaikinOsc(%f, %f)' % (short, long),
       'seed_period': max([short, long]),
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/chande_momentum_oscillator.py
+++ b/bfxhfindicators/chande_momentum_oscillator.py
@@ -1,19 +1,18 @@
 from bfxhfindicators.indicator import Indicator
 
 class ChandeMO(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'chandemo',
       'name': 'ChandeMO(%f)' % period,
       'seed_period': period,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/coppock_curve.py
+++ b/bfxhfindicators/coppock_curve.py
@@ -4,18 +4,17 @@ from bfxhfindicators.roc import ROC
 from math import isfinite
 
 class CoppockCurve(Indicator):
-  def __init__(self, args = []):
-    [ wmaLength, longROCLength, shortROCLength ] = args
-
+  def __init__(self, wmaLength, longROCLength, shortROCLength, cache_size=None):
     self._wma = WMA([wmaLength])
     self._shortROC = ROC([shortROCLength])
     self._longROC = ROC([longROCLength])
 
     super().__init__({
-      'args': args,
+      'args': [wmaLength, longROCLength, shortROCLength, cache_size],
       'id': 'coppockcurve',
       'name': 'Coppock Curve(%f, %f, %f)' % (wmaLength, longROCLength, shortROCLength),
-      'seed_period': max([longROCLength + wmaLength, shortROCLength + wmaLength])
+      'seed_period': max([longROCLength + wmaLength, shortROCLength + wmaLength]),
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/detrended_price_oscillator.py
+++ b/bfxhfindicators/detrended_price_oscillator.py
@@ -3,17 +3,16 @@ from bfxhfindicators.sma import SMA
 from math import floor
 
 class DPO(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._pricePeriod = floor(period / 2) + 1
-    self._sma = SMA([period])
+    self._sma = SMA(period, cache_size)
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'dpo',
       'name': 'DPO(%f)' % period,
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/donchian_channels.py
+++ b/bfxhfindicators/donchian_channels.py
@@ -1,19 +1,18 @@
 from bfxhfindicators.indicator import Indicator
 
 class DC(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'dc',
       'name': 'DC(%f)' % period,
       'seed_period': period,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def reset(self):
@@ -34,7 +33,7 @@ class DC(Indicator):
 
     super().update({
       'upper': maxHigh,
-      'middle': (maxHigh + mmaxHigh) / 2,
+      'middle': (maxHigh + minLow) / 2,
       'lower': minLow
     })
     return self.v()

--- a/bfxhfindicators/ease_of_movement.py
+++ b/bfxhfindicators/ease_of_movement.py
@@ -3,20 +3,19 @@ from bfxhfindicators.sma import SMA
 from math import isfinite
 
 class EOM(Indicator):
-  def __init__(self, args = []):
-    [ divisor, length ] = args
-
+  def __init__(self, divisor, length, cache_size=None):
     self._d = divisor
-    self._sma = SMA([length])
+    self._sma = SMA(length, cache_size)
     self._lastCandle = None
 
     super().__init__({
-      'args': args,
+      'args': [divisor, length, cache_size],
       'id': 'eom',
       'name': 'EOM(%f, %f)' % (divisor, length),
       'seed_period': length,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/ema.py
+++ b/bfxhfindicators/ema.py
@@ -1,14 +1,13 @@
 from bfxhfindicators.indicator import Indicator
 
 class EMA(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'ema',
       'name': 'EMA(%f)' % (period),
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
 
     self._a = 2 / (period + 1)

--- a/bfxhfindicators/ema_vol.py
+++ b/bfxhfindicators/ema_vol.py
@@ -3,18 +3,17 @@ from bfxhfindicators.ema import EMA
 from math import isfinite
 
 class EMAVolume(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
-    self._ema = EMA([period])
+  def __init__(self, period, cache_size=None):
+    self._ema = EMA(period)
 
     super().__init__({
-      'args': args,
+      'args': [period],
       'id': 'emavol',
       'name': 'EMA Vol(%f)' % period,
       'seed_period': period,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/envelope.py
+++ b/bfxhfindicators/envelope.py
@@ -3,17 +3,16 @@ from bfxhfindicators.sma import SMA
 from math import isfinite
 
 class Envelope(Indicator):
-  def __init__(self, args = []):
-    [ length, percent ] = args
-
-    self._sma = SMA([length])
+  def __init__(self, length, percent, cache_size=None):
+    self._sma = SMA(length, cache_size)
     self._p = percent / 100
 
     super().__init__({
-      'args': args,
+      'args': [length, percent, cache_size],
       'id': 'env',
       'name': 'Env(%f, %f)' % (length, percent),
       'seed_period': length,
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/indicator.py
+++ b/bfxhfindicators/indicator.py
@@ -1,17 +1,26 @@
 from math import isfinite
+from collections import deque
+
 
 class Indicator:
-  def __init__(self, params = {}):
+  def __init__(self, params=None):
+    if not params:
+        raise
+
     self._name = params['name']
     self._seed_period = params['seed_period']
     self._id = params['id']
     self._args = params['args']
     self._data_type = params.get('data_type') or '*'
     self._data_key = params.get('data_key') or 'close'
+    self._cache_size = params.get('cache_size')
     self.reset()
 
   def reset(self):
-    self._values = []
+    if self._cache_size:
+        self._values = deque(maxlen=self._cache_size)
+    else:
+        self._values = []
 
   def l(self):
     return len(self._values)

--- a/bfxhfindicators/know_sure_thing.py
+++ b/bfxhfindicators/know_sure_thing.py
@@ -3,23 +3,32 @@ from bfxhfindicators.roc import ROC
 from bfxhfindicators.sma import SMA
 
 class KST(Indicator):
-  def __init__(self, args = []):
-    [ rocA, rocB, rocC, rocD, smaA, smaB, smaC, smaD, smaSignal ] = args
+  def __init__(self,
+               rocA,
+               rocB,
+               rocC,
+               rocD,
+               smaA,
+               smaB,
+               smaC,
+               smaD,
+               smaSignal,
+               cache_size=None):
 
-    self._rocA = ROC([rocA])
-    self._rocB = ROC([rocB])
-    self._rocC = ROC([rocC])
-    self._rocD = ROC([rocD])
+    self._rocA = ROC(rocA, cache_size)
+    self._rocB = ROC(rocB, cache_size)
+    self._rocC = ROC(rocC, cache_size)
+    self._rocD = ROC(rocD, cache_size)
 
-    self._smaA = SMA([smaA])
-    self._smaB = SMA([smaB])
-    self._smaC = SMA([smaC])
-    self._smaD = SMA([smaD])
+    self._smaA = SMA(smaA, cache_size)
+    self._smaB = SMA(smaB, cache_size)
+    self._smaC = SMA(smaC, cache_size)
+    self._smaD = SMA(smaD, cache_size)
 
     self._smaSignal = SMA([smaSignal])
 
     super().__init__({
-      'args': args,
+      'args': [rocA, rocB, rocC, rocD, smaA, smaB, smaC, smaD, smaSignal, cache_size],
       'id': 'kst',
       'name': 'KST(%f, %f, %f, %f, %f, %f, %f, %f, %f)' % (
         rocA, rocB, rocC, rocD, smaA, smaB, smaC, smaD, smaSignal
@@ -30,7 +39,8 @@ class KST(Indicator):
         rocC + smaC,
         rocD + smaD,
         smaSignal
-      ])
+      ]),
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/macd.py
+++ b/bfxhfindicators/macd.py
@@ -3,18 +3,17 @@ from bfxhfindicators.ema import EMA
 from math import isfinite
 
 class MACD(Indicator):
-  def __init__(self, args = []):
-    [ fastMA, slowMA, signalMA ] = args
-
+  def __init__(self, fastMA, slowMA, signalMA, cache_size=None):
     self._slowEMA = EMA([slowMA])
     self._fastEMA = EMA([fastMA])
     self._signalEMA = EMA([signalMA])
 
     super().__init__({
-      'args': args,
+      'args': [fastMA, slowMA, signalMA, cache_size],
       'id': 'macd',
       'name': 'MACD(%f, %f, %f)' % (fastMA, slowMA, signalMA),
-      'seed_period': max([fastMA, slowMA]) + signalMA
+      'seed_period': max([fastMA, slowMA]) + signalMA,
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/mass_index.py
+++ b/bfxhfindicators/mass_index.py
@@ -2,16 +2,14 @@ from bfxhfindicators.indicator import Indicator
 from bfxhfindicators.ema import EMA
 
 class MassIndex(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._smoothing = period
-    self._singleEMA = EMA([9])
-    self._doubleEMA = EMA([9])
+    self._singleEMA = EMA(9, cache_size)
+    self._doubleEMA = EMA(9, cache_size)
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'mi',
       'name': 'Mass Index(%f)' % period,
       'seed_period': 9 + period,

--- a/bfxhfindicators/momentum.py
+++ b/bfxhfindicators/momentum.py
@@ -1,17 +1,16 @@
 from bfxhfindicators.indicator import Indicator
 
 class Momentum(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'mo',
       'name': 'MO(%f)' % period,
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/net_volume.py
+++ b/bfxhfindicators/net_volume.py
@@ -1,7 +1,10 @@
 from bfxhfindicators.indicator import Indicator
 
 class NetVolume(Indicator):
-  def __init__(self, args = []):
+  def __init__(self, args=None):
+    if not args:
+        args = []
+
     super().__init__({
       'args': args,
       'id': 'nv',

--- a/bfxhfindicators/on_balance_volume.py
+++ b/bfxhfindicators/on_balance_volume.py
@@ -1,7 +1,10 @@
 from bfxhfindicators.indicator import Indicator
 
 class OBV(Indicator):
-  def __init__(self, args = []):
+  def __init__(self, args=None):
+    if not args:
+        args = []
+
     self._lastCandle = None
 
     super().__init__({

--- a/bfxhfindicators/price_channel.py
+++ b/bfxhfindicators/price_channel.py
@@ -1,21 +1,20 @@
 from bfxhfindicators.indicator import Indicator
 
 class PC(Indicator):
-  def __init__(self, args = []):
-    [ period, offset ] = args
-
+  def __init__(self, period, offset, cache_size=None):
     self._p = period
     self._offset = offset
     self._l = period + offset
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, offset, cache_size],
       'id': 'pc',
       'name': 'PC(%f, %f)' % (period, offset),
       'seed_period': period,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/price_oscillator.py
+++ b/bfxhfindicators/price_oscillator.py
@@ -2,18 +2,18 @@ from bfxhfindicators.indicator import Indicator
 from bfxhfindicators.ema import EMA
 
 class PPO(Indicator):
-  def __init__(self, args = []):
-    [ shortPeriod, longPeriod ] = args
+  def __init__(self, shortPeriod, longPeriod, cache_size=None):
 
-    self._shortEMA = EMA([shortPeriod])
-    self._longEMA = EMA([longPeriod])
-    self._signalEMA = EMA([9])
+    self._shortEMA = EMA(shortPeriod, cache_size)
+    self._longEMA = EMA(longPeriod, cache_size)
+    self._signalEMA = EMA(9, cache_size)
 
     super().__init__({
-      'args': args,
+      'args': [shortPeriod, longPeriod, cache_size],
       'id': 'ppo',
       'name': 'PPO(%f, %f)' % (shortPeriod, longPeriod),
-      'seed_period': longPeriod
+      'seed_period': longPeriod,
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/price_volume_trend.py
+++ b/bfxhfindicators/price_volume_trend.py
@@ -1,7 +1,10 @@
 from bfxhfindicators.indicator import Indicator
 
 class PVT(Indicator):
-  def __init__(self, args = []):
+  def __init__(self, args=None):
+    if not args:
+        args = []
+
     self._lastCandle = None
 
     super().__init__({

--- a/bfxhfindicators/relative_vigor_index.py
+++ b/bfxhfindicators/relative_vigor_index.py
@@ -2,20 +2,19 @@ from bfxhfindicators.indicator import Indicator
 from bfxhfindicators.sma import SMA
 
 class RVGI(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
-    self._numeratorSMA = SMA([period])
-    self._denominatorSMA = SMA([period])
+  def __init__(self, period, cache_size=None):
+    self._numeratorSMA = SMA(period, cache_size)
+    self._denominatorSMA = SMA(period, cache_size)
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'rvgi',
       'name': 'RVGI(%f)' % period,
       'seed_period': period,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/relative_volatility_index.py
+++ b/bfxhfindicators/relative_volatility_index.py
@@ -4,19 +4,18 @@ from bfxhfindicators.stddev import StdDeviation
 from math import isfinite
 
 class RVI(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
-    self._stddev = StdDeviation([period])
-    self._uEMA = EMA([period])
-    self._dEMA = EMA([period])
+  def __init__(self, period, cache_size=None):
+    self._stddev = StdDeviation(period, cache_size)
+    self._uEMA = EMA(period, cache_size)
+    self._dEMA = EMA(period, cache_size)
     self._prevInputValue = None
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'rvi',
       'name': 'RVI(%f)' % period,
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/roc.py
+++ b/bfxhfindicators/roc.py
@@ -1,14 +1,13 @@
 from bfxhfindicators.indicator import Indicator
 
 class ROC(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'roc',
       'name': 'ROC(%f)' % (period),
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
 
     self._p = period

--- a/bfxhfindicators/rsi.py
+++ b/bfxhfindicators/rsi.py
@@ -3,19 +3,18 @@ from bfxhfindicators.ema import EMA
 from math import isfinite
 
 class RSI(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
-    self._uEMA = EMA([period])
-    self._dEMA = EMA([period])
+    self._uEMA = EMA(period, cache_size)
+    self._dEMA = EMA(period, cache_size)
     self._prevInputValue = None
  
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'rsi',
       'name': 'RSI(%f)' % (period),
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/sma.py
+++ b/bfxhfindicators/sma.py
@@ -1,17 +1,16 @@
 from bfxhfindicators.indicator import Indicator
 
 class SMA(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'sma',
       'name': 'SMA(%f)' % period,
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/stddev.py
+++ b/bfxhfindicators/stddev.py
@@ -2,17 +2,16 @@ from bfxhfindicators.indicator import Indicator
 from math import pow, sqrt
 
 class StdDeviation(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'stddev',
       'name': 'STDDEV(%f)' % period,
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
 
   def reset(self):

--- a/bfxhfindicators/stochastic.py
+++ b/bfxhfindicators/stochastic.py
@@ -2,16 +2,14 @@ from bfxhfindicators.indicator import Indicator
 from bfxhfindicators.sma import SMA
 
 class Stochastic(Indicator):
-  def __init__(self, args = []):
-    [ period, smoothK, smoothD ] = args
-
+  def __init__(self, period, smoothK, smoothD, cache_size=None):
     self._p = period
     self._buffer = []
-    self._kSMA = SMA([smoothK])
-    self._dSMA = SMA([smoothD])
+    self._kSMA = SMA(smoothK, cache_size)
+    self._dSMA = SMA(smoothD, cache_size)
 
     super().__init__({
-      'args': args,
+      'args': [period, smoothK, smoothD, cache_size],
       'id': 'stoch',
       'name': 'Stoch(%f)' % (period),
       'seed_period': period,

--- a/bfxhfindicators/stochastic_rsi.py
+++ b/bfxhfindicators/stochastic_rsi.py
@@ -4,20 +4,19 @@ from bfxhfindicators.rsi import RSI
 from math import isfinite
 
 class StochasticRSI(Indicator):
-  def __init__(self, args = []):
-    [ lengthRSI, lengthStochastic, smoothStoch, smoothSignal ] = args
-
+  def __init__(self, lengthRSI, lengthStochastic, smoothStoch, smoothSignal, cache_size=None):
     self._buffer = []
     self._l = lengthStochastic
-    self._rsi = RSI([lengthRSI])
-    self._smaStoch = SMA([smoothStoch])
-    self._smaSignal = SMA([smoothSignal])
+    self._rsi = RSI(lengthRSI, cache_size)
+    self._smaStoch = SMA(smoothStoch, cache_size)
+    self._smaSignal = SMA(smoothSignal, cache_size)
 
     super().__init__({
-      'args': args,
+      'args': [lengthRSI, lengthStochastic, smoothStoch, smoothSignal, cache_size],
       'id': 'stochrsi',
       'name': 'Stoch RSI(%f, %f, %f, %f)' % (lengthRSI, lengthStochastic, smoothStoch, smoothSignal),
-      'seed_period': lengthRSI + lengthStochastic + smoothStoch
+      'seed_period': lengthRSI + lengthStochastic + smoothStoch,
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/trix.py
+++ b/bfxhfindicators/trix.py
@@ -3,18 +3,17 @@ from bfxhfindicators.ema import EMA
 from math import isfinite
 
 class TRIX(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
-    self._emaFirst = EMA([period])
-    self._emaSecond = EMA([period])
-    self._emaThird = EMA([period])
+  def __init__(self, period, cache_size=None):
+    self._emaFirst = EMA(period, cache_size)
+    self._emaSecond = EMA(period, cache_size)
+    self._emaThird = EMA(period, cache_size)
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'trix',
       'name': 'TRIX(%f)' % (period),
-      'seed_period': (period * 3) + 1
+      'seed_period': (period * 3) + 1,
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/true_strength_index.py
+++ b/bfxhfindicators/true_strength_index.py
@@ -2,21 +2,20 @@ from bfxhfindicators.indicator import Indicator
 from bfxhfindicators.ema import EMA
 
 class TSI(Indicator):
-  def __init__(self, args = []):
-    [ long, short, signal ] = args
-
-    self._pcEMA = EMA([long])
-    self._pc2EMA = EMA([short])
-    self._apcEMA = EMA([long])
-    self._apc2EMA = EMA([short])
-    self._sEMA = EMA([signal])
+  def __init__(self, long, short, signal, cache_size=None):
+    self._pcEMA = EMA(long, cache_size)
+    self._pc2EMA = EMA(short, cache_size)
+    self._apcEMA = EMA(long, cache_size)
+    self._apc2EMA = EMA(short, cache_size)
+    self._sEMA = EMA(signal, cache_size)
     self._lastPrice = None
 
     super().__init__({
-      'args': args,
+      'args': [short, signal, cache_size],
       'id': 'tsi',
       'name': 'TSI(%f, %f, %f)' % (long, short, signal),
-      'seed_period': max([long, short, signal])
+      'seed_period': max([long, short, signal]),
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/volume_oscillator.py
+++ b/bfxhfindicators/volume_oscillator.py
@@ -2,19 +2,18 @@ from bfxhfindicators.indicator import Indicator
 from bfxhfindicators.ema import EMA
 
 class VO(Indicator):
-  def __init__(self, args = []):
-    [ shortPeriod, longPeriod ] = args
-
-    self._shortEMA = EMA([shortPeriod])
-    self._longEMA = EMA([longPeriod])
+  def __init__(self, shortPeriod, longPeriod, cache_size=None):
+    self._shortEMA = EMA(shortPeriod, cache_size)
+    self._longEMA = EMA(longPeriod, cache_size)
 
     super().__init__({
-      'args': args,
+      'args': [shortPeriod, longPeriod, cache_size],
       'id': 'vo',
       'name': 'VO(%f, %f)' % (shortPeriod, longPeriod),
       'seed_period': longPeriod,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/vwap.py
+++ b/bfxhfindicators/vwap.py
@@ -1,7 +1,10 @@
 from bfxhfindicators.indicator import Indicator
 
 class VWAP(Indicator):
-  def __init__(self, args = []):
+  def __init__(self, args=None):
+    if not args:
+        args = []
+
     self._totalNum = 0
     self._totalDen = 0
     self._lastNum = 0

--- a/bfxhfindicators/vwma.py
+++ b/bfxhfindicators/vwma.py
@@ -1,19 +1,18 @@
 from bfxhfindicators.indicator import Indicator
 
 class VWMA(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'vwma',
       'name': 'VWMA(%f)' % period,
       'seed_period': period,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/williams_r.py
+++ b/bfxhfindicators/williams_r.py
@@ -1,19 +1,18 @@
 from bfxhfindicators.indicator import Indicator
 
 class WilliamsR(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     self._p = period
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'wir',
       'name': 'WR(%f)' % period,
       'seed_period': period,
       'data_type': 'candle',
-      'data_key': '*'
+      'data_key': '*',
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/bfxhfindicators/wma.py
+++ b/bfxhfindicators/wma.py
@@ -1,9 +1,7 @@
 from bfxhfindicators.indicator import Indicator
 
 class WMA(Indicator):
-  def __init__(self, args = []):
-    [ period ] = args
-
+  def __init__(self, period, cache_size=None):
     d = 0
 
     for i in range(period):
@@ -14,10 +12,11 @@ class WMA(Indicator):
     self._buffer = []
 
     super().__init__({
-      'args': args,
+      'args': [period, cache_size],
       'id': 'wma',
       'name': 'WMA(%f)' % period,
-      'seed_period': period
+      'seed_period': period,
+      'cache_size': cache_size
     })
   
   def reset(self):

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,6 @@
 # Usages
 
+* `cache_size` - indicate the fixed size of internal deque
 * `reset()` - clears indicator values
 * `update(value or candle)` - updates the current indicator value with a different data point
 * `add(value or candle)` - adds a new data point/value to the indicator

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from io import open
 here = path.abspath(path.dirname(__file__))
 setup(
     name='bfx-hf-indicators',
-    version='1.0.0',
+    version='1.1.0',
     description='Official Bitfinex Indicator Library for Python',
     long_description='A collection of different trading indicators',
     long_description_content_type='text/markdown',

--- a/tests/accumulative_swing_index_test.py
+++ b/tests/accumulative_swing_index_test.py
@@ -21,7 +21,7 @@ candles = [
 
 class ASITest(unittest.TestCase):
   def test_is_calculated_properly(self):
-    asi = AccumulativeSwingIndex([6400])
+    asi = AccumulativeSwingIndex(limitMoveValue=6400)
     asi.add(candles[0])
     asi.add(candles[1])
     self.assertEqual(round(asi.v(), 13), -0.1190821779318)


### PR DESCRIPTION
### Description:
* it is not safe to use

```python
def func(args=[]):
    balabalabala...
```

it will introduce a shared global `args` variable for every run of this function,  https://stackoverflow.com/a/43255920/3377100

so in this PR, for the sake of safety, the code block above is changed to the following style

```python
def func(args=None):
    if not args:
        args = []
    balabalabala...
```

* use `reset` function for truncate the internal rolling window of base Indicator is not a handy way for developers to use this API, just like `new` and `delete` for C++ programmers, therefore, in this PR, it will be an optional fixed size deque instead of original list to automatically handle the data update for the rolling window

### Breaking changes:
- [x] use explicit argments istead of implicit `args`

### New features:
- [x] base Indicator now can use a fixed size deque as rolling window
